### PR TITLE
クレカ登録時のターボリンク修正

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -16,7 +16,6 @@ class CardsController < ApplicationController
         metadata: {user_id: current_user.id} 
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-      
       if @card.save
         redirect_to root_path #ここにカード登録後のパスを指定
       else

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,4 +7,4 @@
         = link_to "ログアウト",destroy_user_session_path, method: :delete, class:"my__page__function"
         .header__inner__bar__registration
         .header__inner__bar__registration__Rogin
-        = link_to "クレジットカードを登録する",new_card_path, class:"my__page__function2"
+        = link_to "クレジットカードを登録する",new_card_path, class:"my__page__function2","data-turbolinks": false


### PR DESCRIPTION
WHAT：
マイページでクレカを登録する際に他画面から遷移した場合でもクレカ登録ができるようにターボリンクを消す。

WHY：
他画面から遷移した際にもクレカ登録ができるようにするため